### PR TITLE
Minor Improvements

### DIFF
--- a/lib/src/ledger/ledger_ble_connection_manager.dart
+++ b/lib/src/ledger/ledger_ble_connection_manager.dart
@@ -36,11 +36,8 @@ class LedgerBleConnectionManager extends BleConnectionManager {
     StreamSubscription? subscription;
     await disconnect(device);
 
-    subscription = _bleManager
-        .connectToAdvertisingDevice(
+    subscription = _bleManager.connectToDevice(
       id: device.id,
-      withServices: [Uuid.parse(serviceId)],
-      prescanDuration: options?.prescanDuration ?? _options.prescanDuration,
       connectionTimeout:
           options?.connectionTimeout ?? _options.connectionTimeout,
     )

--- a/lib/src/ledger/ledger_gatt_reader.dart
+++ b/lib/src/ledger/ledger_gatt_reader.dart
@@ -57,7 +57,6 @@ class LedgerGattReader {
           _handleData(
             Uint8List.fromList(payload),
             onData: onData,
-            onError: onError,
           );
         } else if (remainingBytes > 0) {
           // wait for next message
@@ -75,10 +74,8 @@ class LedgerGattReader {
   void _handleData(
     Uint8List data, {
     void Function(Uint8List event)? onData,
-    Function? onError,
   }) {
     reset();
-
     onData?.call(data);
   }
 

--- a/lib/src/ledger/ledger_gatt_reader.dart
+++ b/lib/src/ledger/ledger_gatt_reader.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:ledger_flutter/src/exceptions/ledger_exception.dart';
 import 'package:ledger_flutter/src/utils/buffer.dart';
 
 class LedgerGattReader {
@@ -15,8 +14,6 @@ class LedgerGattReader {
   /// The GET VERSION command tag 0x00 is used to query the current version of
   /// the protocol being used
   static const versionCla = 0x00;
-
-  static const errorDataSize = 2;
 
   var currentSequence = 0;
   var remainingBytes = 0;
@@ -82,14 +79,7 @@ class LedgerGattReader {
   }) {
     reset();
 
-    if (data.length > errorDataSize) {
-      onData?.call(data);
-    } else if (data.length == errorDataSize) {
-      final errorCode = ByteData.sublistView(data).getInt16(0);
-      onError?.call(LedgerException(errorCode: errorCode));
-    } else {
-      onError?.call(LedgerException());
-    }
+    onData?.call(data);
   }
 
   /// Reset the reader

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ledger_flutter
 description: A Flutter plugin to scan, connect & sign transactions using your Ledger Nano devices
-version: 1.0.1
+version: 1.0.1-cake
 homepage: https://developers.ledger.com/
 repository: https://github.com/RootSoft/ledger-flutter
 issue_tracker: https://github.com/RootSoft/ledger-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ledger_flutter
 description: A Flutter plugin to scan, connect & sign transactions using your Ledger Nano devices
-version: 1.0.1-cake
+version: 1.0.2
 homepage: https://developers.ledger.com/
 repository: https://github.com/RootSoft/ledger-flutter
 issue_tracker: https://github.com/RootSoft/ledger-flutter/issues


### PR DESCRIPTION
During testing, I noticed that `connectToDevice` works more reliably than `connectToAdvertisingDevice`. 
So I suggest we should use `connectToDevice`. 

I also removed the error handling in the LedgerGattReader's `_handleData` method, because it isn't there for USB, and its assuming all status bytes are errors. That is not always the case.

 